### PR TITLE
DELETE /waitlist 컨트롤러 작성

### DIFF
--- a/srcs/controllers/controller.removeUser2WaitList.tsx
+++ b/srcs/controllers/controller.removeUser2WaitList.tsx
@@ -35,9 +35,16 @@ const removeUser2Waitlist: RequestHandler = async (req, res) => {
             { new: true, runValidators: true }
         ).exec();
 
+        const ChangedWaitlist = await Waitlist.findOneAndUpdate(
+            { subjectName: WaitlistDocument.subjectName },
+            { $pull: { user: WaitlistUserInfo } },
+            { new: true, runValidators: true }
+        ).exec();
+
         res.status(200).json({
             success: true,
             User: ChangedUser,
+            Waitlist: ChangedWaitlist,
         });
     } catch (e) {
         res.status(400).json({

--- a/srcs/controllers/controller.removeUser2WaitList.tsx
+++ b/srcs/controllers/controller.removeUser2WaitList.tsx
@@ -9,6 +9,24 @@ const removeUser2Waitlist: RequestHandler = async (req, res) => {
         if (UserDocument.waitMatching === null)
             throw new Error('This user_ID not registered in any subject');
 
+        const WaitlistDocument = await Waitlist.findOne({
+            subjectName: UserDocument.waitMatching,
+        }).exec();
+        if (WaitlistDocument === null || WaitlistDocument === undefined)
+            throw new Error('This subjectName does not exist.');
+        let WaitlistUserInfo = null;
+        for (let i = 0; i < WaitlistDocument.user.length; i++) {
+            if (WaitlistDocument.user[i].userID === req.params.userId) {
+                WaitlistUserInfo = WaitlistDocument.user[i];
+                break;
+            }
+        }
+        if (WaitlistUserInfo === null) {
+            throw new Error(
+                'This user_ID not registered in ' + WaitlistDocument.subjectName + 'subject'
+            );
+        }
+
         res.status(200).json({
             success: true,
         });

--- a/srcs/controllers/controller.removeUser2WaitList.tsx
+++ b/srcs/controllers/controller.removeUser2WaitList.tsx
@@ -27,8 +27,17 @@ const removeUser2Waitlist: RequestHandler = async (req, res) => {
             );
         }
 
+        const ChangedUser = await User.findOneAndUpdate(
+            { ID: req.params.userId },
+            {
+                waitMatching: null,
+            },
+            { new: true, runValidators: true }
+        ).exec();
+
         res.status(200).json({
             success: true,
+            User: ChangedUser,
         });
     } catch (e) {
         res.status(400).json({

--- a/srcs/controllers/controller.removeUser2WaitList.tsx
+++ b/srcs/controllers/controller.removeUser2WaitList.tsx
@@ -3,6 +3,12 @@ import { User, Waitlist } from '../models';
 
 const removeUser2Waitlist: RequestHandler = async (req, res) => {
     try {
+        const UserDocument = await User.findOne({ ID: req.params.userId }).exec();
+        if (UserDocument === null || UserDocument === undefined)
+            throw new Error('This user_ID does not exist.');
+        if (UserDocument.waitMatching === null)
+            throw new Error('This user_ID not registered in any subject');
+
         res.status(200).json({
             success: true,
         });

--- a/srcs/controllers/controller.removeUser2WaitList.tsx
+++ b/srcs/controllers/controller.removeUser2WaitList.tsx
@@ -1,0 +1,20 @@
+import { RequestHandler } from 'express';
+import { User, Waitlist } from '../models';
+
+const removeUser2Waitlist: RequestHandler = async (req, res) => {
+    try {
+        res.status(200).json({
+            success: true,
+        });
+    } catch (e) {
+        res.status(400).json({
+            success: false,
+            error: {
+                code: e.name,
+                message: e.message,
+            },
+        });
+    }
+};
+
+export default removeUser2Waitlist;

--- a/srcs/controllers/index.tsx
+++ b/srcs/controllers/index.tsx
@@ -2,3 +2,4 @@ export { default as updateTeamState } from './controller.updateTeamState';
 export { default as getUser } from './controller.getUser';
 export { default as addUser2Team } from './controller.addUser2Team';
 export { default as addUser2WaitList } from './controller.addUser2Waitlist';
+export { default as removeUser2WaitList } from './controller.removeUser2WaitList';

--- a/srcs/routes/index.tsx
+++ b/srcs/routes/index.tsx
@@ -10,5 +10,6 @@ router.get('/user', controller.getUser);
 router.get('/user/:userId', controller.getUser);
 router.post('/waitlist', controller.addUser2WaitList);
 router.post('/addmember', controller.addUser2Team);
+router.delete('/waitlist/:userId', controller.removeUser2WaitList);
 
 export default router;


### PR DESCRIPTION
resolved : #31

문제사항 기록

- express에서 delete요청 메소드의 경우 body에 params를 보낼 수 없어서 
   delete /waitlist/userId 형태로 진행중
- array of object에서 원하는 객체만 삭제할 때무는 UpdateOne()메소드의 $pull문법을 사용합니다.