### PR TITLE
fix : API문서, 담당 api 네이밍 통일

### DIFF
--- a/srcs/controllers/controller.addUser2Waitlist.tsx
+++ b/srcs/controllers/controller.addUser2Waitlist.tsx
@@ -4,37 +4,37 @@ import { User, Waitlist } from '../models';
 
 const addUser2Waitlist: RequestHandler = async (req, res) => {
     try {
-        await axios.get('https://api.github.com/users/' + req.body.gitid);
+        await axios.get('https://api.github.com/users/' + req.body.gitName);
 
-        const UserDocument = await User.findOne({ ID: req.body.user_ID }).exec();
+        const UserDocument = await User.findOne({ ID: req.body.userId }).exec();
         if (UserDocument === null || UserDocument === undefined)
-            throw new Error('This user_ID does not exist.');
+            throw new Error('This userId does not exist.');
 
         const WaitlistDocument = await Waitlist.findOne({
-            subject_name: req.body.subject_name,
+            subjectName: req.body.subjectName,
         }).exec();
         if (WaitlistDocument === null || WaitlistDocument === undefined)
-            throw new Error('Invalid subject_name');
+            throw new Error('Invalid subjectName');
         for (let i = 0; i < WaitlistDocument.user.length; i++) {
-            if (WaitlistDocument.user[i].user_ID === req.body.user_ID)
+            if (WaitlistDocument.user[i].userID === req.body.userId)
                 throw new Error(
-                    'The user is already registered in the ' + req.body.subject_name + ' subject'
+                    'The user is already registered in the ' + req.body.subjectName + ' subject'
                 );
         }
 
         const ChangedUser = await User.findOneAndUpdate(
-            { ID: req.body.user_ID },
+            { ID: req.body.userId },
             {
-                waitMatching: req.body.subject_name,
-                gitID: req.body.gitid,
+                waitMatching: req.body.subjectName,
+                gitName: req.body.gitName,
                 cluster: req.body.cluster,
             },
             { new: true, runValidators: true }
         ).exec();
 
-        const SubjectUser = { user_ID: req.body.user_ID };
+        const SubjectUser = { userID: req.body.userId };
         const ChangedWaitlist = await Waitlist.findOneAndUpdate(
-            { subject_name: req.body.subject_name },
+            { subjectName: req.body.subjectName },
             { $push: { user: SubjectUser } },
             { new: true, runValidators: true }
         ).exec();
@@ -45,7 +45,7 @@ const addUser2Waitlist: RequestHandler = async (req, res) => {
             Waitlist: ChangedWaitlist,
         });
     } catch (e) {
-        if (e.request) e.message = 'not found gitid';
+        if (e.request) e.message = 'not found gitName';
 
         res.status(400).json({
             success: false,

--- a/srcs/controllers/controller.addUser2Waitlist.tsx
+++ b/srcs/controllers/controller.addUser2Waitlist.tsx
@@ -6,9 +6,9 @@ const addUser2Waitlist: RequestHandler = async (req, res) => {
     try {
         await axios.get('https://api.github.com/users/' + req.body.gitName);
 
-        const UserDocument = await User.findOne({ ID: req.body.userId }).exec();
+        const UserDocument = await User.findOne({ ID: req.body.userID }).exec();
         if (UserDocument === null || UserDocument === undefined)
-            throw new Error('This userId does not exist.');
+            throw new Error('This userID does not exist.');
 
         const WaitlistDocument = await Waitlist.findOne({
             subjectName: req.body.subjectName,
@@ -16,14 +16,14 @@ const addUser2Waitlist: RequestHandler = async (req, res) => {
         if (WaitlistDocument === null || WaitlistDocument === undefined)
             throw new Error('Invalid subjectName');
         for (let i = 0; i < WaitlistDocument.user.length; i++) {
-            if (WaitlistDocument.user[i].userID === req.body.userId)
+            if (WaitlistDocument.user[i].userID === req.body.userID)
                 throw new Error(
                     'The user is already registered in the ' + req.body.subjectName + ' subject'
                 );
         }
 
         const ChangedUser = await User.findOneAndUpdate(
-            { ID: req.body.userId },
+            { ID: req.body.userID },
             {
                 waitMatching: req.body.subjectName,
                 gitName: req.body.gitName,
@@ -32,7 +32,7 @@ const addUser2Waitlist: RequestHandler = async (req, res) => {
             { new: true, runValidators: true }
         ).exec();
 
-        const SubjectUser = { userID: req.body.userId };
+        const SubjectUser = { userID: req.body.userID };
         const ChangedWaitlist = await Waitlist.findOneAndUpdate(
             { subjectName: req.body.subjectName },
             { $push: { user: SubjectUser } },

--- a/srcs/controllers/controller.removeUser2WaitList.tsx
+++ b/srcs/controllers/controller.removeUser2WaitList.tsx
@@ -5,9 +5,9 @@ const removeUser2Waitlist: RequestHandler = async (req, res) => {
     try {
         const UserDocument = await User.findOne({ ID: req.params.userId }).exec();
         if (UserDocument === null || UserDocument === undefined)
-            throw new Error('This user_ID does not exist.');
+            throw new Error('This userId does not exist.');
         if (UserDocument.waitMatching === null)
-            throw new Error('This user_ID not registered in any subject');
+            throw new Error('This userId not registered in any subject');
 
         const WaitlistDocument = await Waitlist.findOne({
             subjectName: UserDocument.waitMatching,

--- a/srcs/controllers/controller.removeUser2WaitList.tsx
+++ b/srcs/controllers/controller.removeUser2WaitList.tsx
@@ -3,11 +3,11 @@ import { User, Waitlist } from '../models';
 
 const removeUser2Waitlist: RequestHandler = async (req, res) => {
     try {
-        const UserDocument = await User.findOne({ ID: req.params.userId }).exec();
+        const UserDocument = await User.findOne({ ID: req.params.userID }).exec();
         if (UserDocument === null || UserDocument === undefined)
-            throw new Error('This userId does not exist.');
+            throw new Error('This userID does not exist.');
         if (UserDocument.waitMatching === null)
-            throw new Error('This userId not registered in any subject');
+            throw new Error('This userID not registered in any subject');
 
         const WaitlistDocument = await Waitlist.findOne({
             subjectName: UserDocument.waitMatching,
@@ -16,19 +16,19 @@ const removeUser2Waitlist: RequestHandler = async (req, res) => {
             throw new Error('This subjectName does not exist.');
         let WaitlistUserInfo = null;
         for (let i = 0; i < WaitlistDocument.user.length; i++) {
-            if (WaitlistDocument.user[i].userID === req.params.userId) {
+            if (WaitlistDocument.user[i].userID === req.params.userID) {
                 WaitlistUserInfo = WaitlistDocument.user[i];
                 break;
             }
         }
         if (WaitlistUserInfo === null) {
             throw new Error(
-                'This user_ID not registered in ' + WaitlistDocument.subjectName + 'subject'
+                'This userID not registered in ' + WaitlistDocument.subjectName + 'subject'
             );
         }
 
         const ChangedUser = await User.findOneAndUpdate(
-            { ID: req.params.userId },
+            { ID: req.params.userID },
             {
                 waitMatching: null,
             },

--- a/srcs/routes/index.tsx
+++ b/srcs/routes/index.tsx
@@ -21,7 +21,7 @@ router.patch('/team/:teamid', controller.updateTeamState);
 router.get('/user', controller.getUser);
 router.get('/user/:userId', controller.getUser);
 router.post('/waitlist', controller.addUser2WaitList);
-router.delete('/waitlist/:userId', controller.removeUser2WaitList);
+router.delete('/waitlist/:userID', controller.removeUser2WaitList);
 router.post('/addmember', controller.addUser2Team);
 router.get('/team', controller.getTeam);
 router.get('/team/:teamId', controller.getTeam);

--- a/srcs/routes/index.tsx
+++ b/srcs/routes/index.tsx
@@ -21,6 +21,7 @@ router.patch('/team/:teamid', controller.updateTeamState);
 router.get('/user', controller.getUser);
 router.get('/user/:userId', controller.getUser);
 router.post('/waitlist', controller.addUser2WaitList);
+router.delete('/waitlist/:userId', controller.removeUser2WaitList);
 router.post('/addmember', controller.addUser2Team);
 router.get('/team', controller.getTeam);
 router.get('/team/:teamId', controller.getTeam);

--- a/srcs/swagger/controller/addUser2Waitlist.tsx
+++ b/srcs/swagger/controller/addUser2Waitlist.tsx
@@ -7,7 +7,7 @@
  *        required: true
  *        description: |
  *          ### 변경할 상태 정보입니다.</br>
- *          - userId - 매칭 대기할 user의 ID값입니다.</br>
+ *          - userID - 매칭 대기할 user의 ID값입니다.</br>
  *          - subjectName - 매칭 대기할 subject의 이름입니다.</br>
  *          - gitName - user의 github username입니다.</br>
  *          - cluster - 선호하는 클러스터입니다.
@@ -16,7 +16,7 @@
  *            schema:
  *              type: object
  *              properties:
- *                userId:
+ *                userID:
  *                  type: string
  *                subjectName:
  *                  type: string
@@ -26,7 +26,7 @@
  *                  type: string
  *                  enum: [개포, 서초]
  *              example:
- *                "userId": "kwlee"
+ *                "userID": "kwlee"
  *                "subjectName": "ft_printf"
  *                "gitName": "Lks9172"
  *                "cluster": "개포"
@@ -48,8 +48,8 @@
  *              description: |
  *                오류가 발생해 특정 user를 subject 랜덤 매칭 대기열에 추가하지 못했을 경우 다음 결과가 반환됩니다.</br></br>
  *                -오류 예시</br>
- *                - 존재하지 않는 userId가 들어온 경우 <br>
- *                - 해당 userId가 해당 subject 랜덤 매칭 대기열에 이미 추가되어있는 경우 <br>
+ *                - 존재하지 않는 userID가 들어온 경우 <br>
+ *                - 해당 userID가 해당 subject 랜덤 매칭 대기열에 이미 추가되어있는 경우 <br>
  *                - 존재하지 않는 subjectName값이 들어온 경우 <br>
  *                - 존재하지 않는 gitName값이 들어온 경우 <br>
  *              content:
@@ -69,5 +69,5 @@
  *                            success: false
  *                            error:
  *                              code: Error
- *                              message: This userId does not exist.
+ *                              message: This userID does not exist.
  */

--- a/srcs/swagger/controller/addUser2Waitlist.tsx
+++ b/srcs/swagger/controller/addUser2Waitlist.tsx
@@ -7,28 +7,28 @@
  *        required: true
  *        description: |
  *          ### 변경할 상태 정보입니다.</br>
- *          - user_ID - 매칭 대기할 user의 ID값입니다.</br>
- *          - subject_name - 매칭 대기할 subject의 이름입니다.</br>
- *          - gitid - user의 gitid입니다.</br>
+ *          - userId - 매칭 대기할 user의 ID값입니다.</br>
+ *          - subjectName - 매칭 대기할 subject의 이름입니다.</br>
+ *          - gitName - user의 github username입니다.</br>
  *          - cluster - 선호하는 클러스터입니다.
  *        content:
  *          application/json:
  *            schema:
  *              type: object
  *              properties:
- *                user_ID:
+ *                userId:
  *                  type: string
- *                subject_name:
+ *                subjectName:
  *                  type: string
- *                gitid:
+ *                gitName:
  *                  type: string
  *                cluster:
  *                  type: string
  *                  enum: [개포, 서초]
  *              example:
- *                "user_ID": "kwlee"
- *                "subject_name": "ft_printf"
- *                "gitid": "Lks9172"
+ *                "userId": "kwlee"
+ *                "subjectName": "ft_printf"
+ *                "gitName": "Lks9172"
  *                "cluster": "개포"
  *      responses:
  *          200:
@@ -48,10 +48,10 @@
  *              description: |
  *                오류가 발생해 특정 user를 subject 랜덤 매칭 대기열에 추가하지 못했을 경우 다음 결과가 반환됩니다.</br></br>
  *                -오류 예시</br>
- *                - 존재하지 않는 user_ID값이 들어온 경우 <br>
- *                - 해당 user_ID가 해당 subject 랜덤 매칭 대기열에 이미 추가되어있는 경우 <br>
- *                - 존재하지 않는 subject_name값이 들어온 경우 <br>
- *                - 존재하지 않는 gitid값이 들어온 경우 <br>
+ *                - 존재하지 않는 userId가 들어온 경우 <br>
+ *                - 해당 userId가 해당 subject 랜덤 매칭 대기열에 이미 추가되어있는 경우 <br>
+ *                - 존재하지 않는 subjectName값이 들어온 경우 <br>
+ *                - 존재하지 않는 gitName값이 들어온 경우 <br>
  *              content:
  *                  application/json:
  *                      schema:
@@ -69,5 +69,5 @@
  *                            success: false
  *                            error:
  *                              code: Error
- *                              message: This user_ID does not exist.
+ *                              message: This userId does not exist.
  */

--- a/srcs/swagger/controller/removeUser2WaitList.tsx
+++ b/srcs/swagger/controller/removeUser2WaitList.tsx
@@ -32,10 +32,10 @@
  *              description: |
  *                오류가 발생해 특정 user를 subject 랜덤 매칭 대기열에서 삭제하지 못했을 경우 다음 결과가 반환됩니다.</br></br>
  *                -오류 예시</br>
- *                - 존재하지 않는 user_ID값이 들어온 경우 <br>
- *                - 해당 user_ID가 랜덤 매칭 대기중인 subject가 없는 경우 <br>
- *                - 존재하지 않는 subject_name값이 들어온 경우 <br>
- *                - 해당 subject 랜덤 매칭 대기열에 존재하지 않는 경우 <br>
+ *                - 존재하지 않는 userId 들어온 경우 <br>
+ *                - 해당 userId 랜덤 매칭 대기중인 subject가 없는 경우 <br>
+ *                - 입력된 userId를 가진 user가 존재하지 않는 subject에 등록되어 있는 경우 <br>
+ *                - 입력된 userId를 가진 user가 subject 랜덤 매칭 대기열에 등록되어 있지 않은 경우 <br>
  *              content:
  *                  application/json:
  *                      schema:

--- a/srcs/swagger/controller/removeUser2WaitList.tsx
+++ b/srcs/swagger/controller/removeUser2WaitList.tsx
@@ -1,16 +1,16 @@
 /**
  * @swagger
- * /waitlist/{userId}:
+ * /waitlist/{userID}:
  *  delete:
  *      description: 특정 user를 subject 랜덤 매칭 대기열에서 삭제하는 API입니다.
  *      parameters:
  *      - in: path
- *        name: userId
+ *        name: userID
  *        required: true
  *        schema:
  *          type: string
  *          minimum: 1
- *        description: 랜덤 매칭 대기를 취소할 user의 id입니다.
+ *        description: 랜덤 매칭 대기를 취소할 user의 ID입니다.
  *      responses:
  *          200:
  *              description: 특정 user를 subject 랜덤 매칭 대기열에서 성공적으로 삭제하였을 경우 다음 결과가 반환됩니다. <br><br>
@@ -32,10 +32,10 @@
  *              description: |
  *                오류가 발생해 특정 user를 subject 랜덤 매칭 대기열에서 삭제하지 못했을 경우 다음 결과가 반환됩니다.</br></br>
  *                -오류 예시</br>
- *                - 존재하지 않는 userId 들어온 경우 <br>
- *                - 해당 userId 랜덤 매칭 대기중인 subject가 없는 경우 <br>
- *                - 입력된 userId를 가진 user가 존재하지 않는 subject에 등록되어 있는 경우 <br>
- *                - 입력된 userId를 가진 user가 subject 랜덤 매칭 대기열에 등록되어 있지 않은 경우 <br>
+ *                - 존재하지 않는 userID 들어온 경우 <br>
+ *                - 해당 userID 랜덤 매칭 대기중인 subject가 없는 경우 <br>
+ *                - 입력된 userID를 가진 user가 존재하지 않는 subject에 등록되어 있는 경우 <br>
+ *                - 입력된 userID를 가진 user가 subject 랜덤 매칭 대기열에 등록되어 있지 않은 경우 <br>
  *              content:
  *                  application/json:
  *                      schema:
@@ -53,5 +53,5 @@
  *                            success: false
  *                            error:
  *                              code: Error
- *                              message: This user_ID does not exist.
+ *                              message: This userID does not exist.
  */


### PR DESCRIPTION
- controller.addUser2Waitlist.tsx의 파라미터, 변수명에  camelcase적용
- controller.removeUser2Waitlist.tsx의 파라미터, 변수명에 camelcase적용
- routes/index.tsx에 delete/waitlist/{userId} api 라우팅 코드 추가
- post/waitlist api문서 api코드 수정에 따라 변경
- delete/waitlist/{userId} api문서  api코드 수정에 따라 변경

resolved:75