### PR TITLE
[fix] 코드의 네이밍을  API 문서, 다이어그램과 통일

### DIFF
--- a/srcs/controllers/controller.creatGitRepo.tsx
+++ b/srcs/controllers/controller.creatGitRepo.tsx
@@ -14,7 +14,7 @@ const checkError = (team) => {
 
 const createGitRepo: RequestHandler = async (req, res) => {
     try {
-        let team = await Team.findOne({ ID: req.params.teamId });
+        let team = await Team.findOne({ ID: req.params.teamID });
         checkError(team);
         const createResult = await axios({
             method: 'post',
@@ -32,11 +32,11 @@ const createGitRepo: RequestHandler = async (req, res) => {
         const gitUrl = createResult.data.html_url;
         if (gitUrl === undefined) throw new Error('git Repository creation failed');
         await Team.updateOne(
-            { ID: req.params.teamId },
+            { ID: req.params.teamID },
             { gitLink: gitUrl },
             { runValidators: true }
         );
-        team = await Team.findOne({ ID: req.params.teamId });
+        team = await Team.findOne({ ID: req.params.teamID });
         res.json({
             success: true,
             team,

--- a/srcs/controllers/controller.creatGitRepo.tsx
+++ b/srcs/controllers/controller.creatGitRepo.tsx
@@ -14,7 +14,7 @@ const checkError = (team) => {
 
 const createGitRepo: RequestHandler = async (req, res) => {
     try {
-        let team = await Team.findOne({ ID: req.params.teamid });
+        let team = await Team.findOne({ ID: req.params.teamId });
         checkError(team);
         const createResult = await axios({
             method: 'post',
@@ -29,14 +29,14 @@ const createGitRepo: RequestHandler = async (req, res) => {
                 private: true,
             },
         });
-        const git_url = createResult.data.html_url;
-        if (git_url === undefined) throw new Error('git creation failed');
+        const gitUrl = createResult.data.html_url;
+        if (gitUrl === undefined) throw new Error('git Repository creation failed');
         await Team.updateOne(
-            { ID: req.params.teamid },
-            { gitLink: git_url },
+            { ID: req.params.teamId },
+            { gitLink: gitUrl },
             { runValidators: true }
         );
-        team = await Team.findOne({ ID: req.params.teamid });
+        team = await Team.findOne({ ID: req.params.teamId });
         res.json({
             success: true,
             team,

--- a/srcs/controllers/controller.updateTeamState.tsx
+++ b/srcs/controllers/controller.updateTeamState.tsx
@@ -3,15 +3,15 @@ import { Team } from '../models';
 
 const updateTeamState: RequestHandler = async (req, res) => {
     try {
-        let team = await Team.findOne({ ID: req.params.teamid });
+        let team = await Team.findOne({ ID: req.params.teamId });
         if (req.body.state === undefined || team === null)
             throw new Error('no such team id or state');
         await Team.updateOne(
-            { ID: req.params.teamid },
+            { ID: req.params.teamId },
             { state: req.body.state },
             { runValidators: true }
         );
-        team = await Team.findOne({ ID: req.params.teamid });
+        team = await Team.findOne({ ID: req.params.teamId });
         res.json({
             success: true,
             team: team,

--- a/srcs/controllers/controller.updateTeamState.tsx
+++ b/srcs/controllers/controller.updateTeamState.tsx
@@ -3,15 +3,15 @@ import { Team } from '../models';
 
 const updateTeamState: RequestHandler = async (req, res) => {
     try {
-        let team = await Team.findOne({ ID: req.params.teamId });
+        let team = await Team.findOne({ ID: req.params.teamID });
         if (req.body.state === undefined || team === null)
             throw new Error('no such team id or state');
         await Team.updateOne(
-            { ID: req.params.teamId },
+            { ID: req.params.teamID },
             { state: req.body.state },
             { runValidators: true }
         );
-        team = await Team.findOne({ ID: req.params.teamId });
+        team = await Team.findOne({ ID: req.params.teamID });
         res.json({
             success: true,
             team: team,

--- a/srcs/controllers/index.tsx
+++ b/srcs/controllers/index.tsx
@@ -4,4 +4,4 @@ export { default as addUser2Team } from './controller.addUser2Team';
 export { default as addUser2WaitList } from './controller.addUser2Waitlist';
 export { default as getTeam } from './controller.getTeam';
 export { default as removeUser2WaitList } from './controller.removeUser2WaitList';
-export { default as createGitRepository } from './controller.creatGitRepo';
+export { default as createGitRepo } from './controller.creatGitRepo';

--- a/srcs/routes/index.tsx
+++ b/srcs/routes/index.tsx
@@ -17,13 +17,13 @@ router.get('/login/redirect', granted);
 router.get('/login/fail', fail);
 
 router.use(isAuth);
-router.patch('/team/:teamid', controller.updateTeamState);
 router.get('/user', controller.getUser);
 router.get('/user/:userId', controller.getUser);
 router.post('/waitlist', controller.addUser2WaitList);
 router.post('/addmember', controller.addUser2Team);
 router.get('/team', controller.getTeam);
 router.get('/team/:teamId', controller.getTeam);
-router.post('/team/creategitrepo/:teamid', controller.createGitRepository);
+router.patch('/team/:teamId', controller.updateTeamState);
+router.post('/team/creategitrepo/:teamId', controller.createGitRepo);
 
 export default router;

--- a/srcs/routes/index.tsx
+++ b/srcs/routes/index.tsx
@@ -23,7 +23,7 @@ router.post('/waitlist', controller.addUser2WaitList);
 router.post('/addmember', controller.addUser2Team);
 router.get('/team', controller.getTeam);
 router.get('/team/:teamId', controller.getTeam);
-router.patch('/team/:teamId', controller.updateTeamState);
-router.post('/team/creategitrepo/:teamId', controller.createGitRepo);
+router.patch('/team/:teamID', controller.updateTeamState);
+router.post('/team/creategitrepo/:teamID', controller.createGitRepo);
 
 export default router;

--- a/srcs/swagger/controller/updateTeamState.tsx
+++ b/srcs/swagger/controller/updateTeamState.tsx
@@ -1,11 +1,11 @@
 /**
  * @swagger
- * /team/{teamId}:
+ * /team/{teamID}:
  *  patch:
  *      description: 팀의 상태를 변경시키는 API입니다.
  *      parameters:
  *      - in: path
- *        name: teamId
+ *        name: teamID
  *        required: true
  *        schema:
  *          type: string
@@ -15,10 +15,10 @@
  *        required: true
  *        description: |
  *          ### 변경할 상태 정보입니다.</br>
- *          - progress - 매칭이 완료되어 프로젝트 진행 중입니다.</br>
- *          - end - 프로젝트가 종료되어 매칭이 팀이 닫혔습니다.</br>
- *          - less_member - 팀 멤버 수가 적은 상태로 매칭되었습니다</br>
- *          - wait_member - 팀 멤버를 기다리는 중입니다.
+ *          - progress - 팀 멤버가 3명 이상이 되어 정상적으로 진행 중입니다.</br>
+ *          - end - 팀의 학습이 종료되어 팀이 닫혔습니다.</br>
+ *          - less_member - 팀 멤버가 3명 미만으로 진행중이고 추가 멤버를 받지 않는 상태입니다</br>
+ *          - wait_member - 팀 멤버가 3명 미만으로 진행중이고 추가 멤버를 받는 상태입니다.
  *        content:
  *          application/json:
  *            schema:


### PR DESCRIPTION
- controller.creatGitRepo.tsx의 teamid를 teadId로 수정
- controller.updateTeamState.tsx의 teamid를 teadId로 수정
- controller/index.tsx에서 export할 함수 명을 controller.creatGitRepo.tsx의 함수명과 동일하게 변경
- routes/index.tsx 에서 teamid를 teamID로 변경, team 관련된 것들끼리 모이도록 순서 변경

resolved: #70 