### PR TITLE
fix : swagger wailist모델 오타 수정

### DIFF
--- a/srcs/swagger/schema/waitlist.tsx
+++ b/srcs/swagger/schema/waitlist.tsx
@@ -10,7 +10,7 @@
  *                  user:
  *                      type: array
  *                      items:
- *                          tpye: object
+ *                          type: object
  *                          properties:
  *                              userID:
  *                                  type: string


### PR DESCRIPTION
- user의 items type를 tpye로 작성된 부분 수정

<img width="304" alt="스크린샷 2021-06-23 오후 6 42 34" src="https://user-images.githubusercontent.com/44085243/123075007-c73cf600-d452-11eb-8d8f-a0e58f9c29c8.png">

정상동작하지만 오타가 발견되어 수정했습니다.


resolved: #75 