### PR TITLE
[hotfix] updateTeamState 팀 아이디를 못찾는 현상 버그 해결

### DIFF
--- a/srcs/controllers/controller.updateTeamState.tsx
+++ b/srcs/controllers/controller.updateTeamState.tsx
@@ -1,11 +1,16 @@
 import { RequestHandler } from 'express';
 import { Team } from '../models';
 
+const checkError = (team, teamID, state) => {
+    if (state === undefined) throw new Error('state value is missing');
+    else if (team === null)
+        throw new Error(`teamID params :'${teamID}'. no such teamID in database.`);
+};
+
 const updateTeamState: RequestHandler = async (req, res) => {
     try {
         let team = await Team.findOne({ ID: req.params.teamID });
-        if (req.body.state === undefined || team === null)
-            throw new Error('no such team id or state');
+        checkError(team, req.params.teamID, req.body.state);
         await Team.updateOne(
             { ID: req.params.teamID },
             { state: req.body.state },

--- a/srcs/routes/index.tsx
+++ b/srcs/routes/index.tsx
@@ -4,7 +4,7 @@ import * as controller from '../controllers';
 import { fail, login, granted } from '../auth';
 import swaggerSpec from '../swagger/option';
 import axios from 'axios';
-
+import { Team } from '../models';
 const router = Router();
 /*
     Set your router, but must check order of router
@@ -18,7 +18,6 @@ router.get('/login/redirect', granted);
 router.get('/login/fail', fail);
 
 //router.use(isAuth);
-router.patch('/team/:teamid', controller.updateTeamState);
 router.get('/user', controller.getUser);
 router.get('/user/:userID', controller.getUser);
 router.get('/waitlist', controller.getWaitlist);
@@ -29,5 +28,10 @@ router.get('/team', controller.getTeam);
 router.get('/team/:teamId', controller.getTeam);
 router.patch('/team/:teamID', controller.updateTeamState);
 router.post('/team/creategitrepo/:teamID', controller.createGitRepo);
+
+router.post('/team', async (req, res) => {
+    const team = await Team.create(req.body);
+    res.json({ team });
+});
 
 export default router;

--- a/srcs/routes/index.tsx
+++ b/srcs/routes/index.tsx
@@ -4,7 +4,6 @@ import * as controller from '../controllers';
 import { fail, login, granted } from '../auth';
 import swaggerSpec from '../swagger/option';
 import axios from 'axios';
-import { Team } from '../models';
 const router = Router();
 /*
     Set your router, but must check order of router
@@ -28,10 +27,5 @@ router.get('/team', controller.getTeam);
 router.get('/team/:teamId', controller.getTeam);
 router.patch('/team/:teamID', controller.updateTeamState);
 router.post('/team/creategitrepo/:teamID', controller.createGitRepo);
-
-router.post('/team', async (req, res) => {
-    const team = await Team.create(req.body);
-    res.json({ team });
-});
 
 export default router;


### PR DESCRIPTION
- 변수명 통일할때 routers/index.tsx에서 기존 라우팅을 안지워서 생긴
  문제였습니다. 해당 부분을 삭제해 해결했습니다.
 -에러처리가 빈약한것 같아 들어온 팀 아이디를 다시 보여주도록 에러
 메세지를 수정했습니다.

resolved: #97 