### PR TITLE
 GET team API progress, subject 필터링 추가

### DIFF
--- a/srcs/controllers/controller.getTeam.tsx
+++ b/srcs/controllers/controller.getTeam.tsx
@@ -7,7 +7,6 @@ const getTeam: RequestHandler = async (req, res) => {
         if (!teamID) {
             let limit = 5;
             let page = 0;
-
             if (req.query.limit) {
                 limit = parseInt(req.query.limit as string);
             }
@@ -15,6 +14,20 @@ const getTeam: RequestHandler = async (req, res) => {
                 page = parseInt(req.query.page as string);
             }
             const allTeams = await Team.find({});
+            if (req.query.progress as string === 'true') {
+                for (let i = allTeams.length - 1; i >= 0; i--) {
+                    if (allTeams[i].state === 'end') {
+                        allTeams.splice(i, 1);
+                    }
+                }
+            }
+            if (req.query.subject) {
+                for (let i = allTeams.length - 1; i >= 0; i--) {
+                    if (allTeams[i].subject !== req.query.subject) {
+                            allTeams.splice(i, 1);
+                    }
+                }
+            }
             if (!req.query.page && !req.query.limit) {
                 res.status(200).json({
                     success: true,

--- a/srcs/controllers/controller.getTeam.tsx
+++ b/srcs/controllers/controller.getTeam.tsx
@@ -7,6 +7,7 @@ const getTeam: RequestHandler = async (req, res) => {
         if (!teamID) {
             let limit = 5;
             let page = 0;
+
             if (req.query.limit) {
                 limit = parseInt(req.query.limit as string);
             }
@@ -14,7 +15,7 @@ const getTeam: RequestHandler = async (req, res) => {
                 page = parseInt(req.query.page as string);
             }
             const allTeams = await Team.find({});
-            if (req.query.progress as string === 'true') {
+            if ((req.query.progress as string) === 'true') {
                 for (let i = allTeams.length - 1; i >= 0; i--) {
                     if (allTeams[i].state === 'end') {
                         allTeams.splice(i, 1);
@@ -24,7 +25,7 @@ const getTeam: RequestHandler = async (req, res) => {
             if (req.query.subject) {
                 for (let i = allTeams.length - 1; i >= 0; i--) {
                     if (allTeams[i].subject !== req.query.subject) {
-                            allTeams.splice(i, 1);
+                        allTeams.splice(i, 1);
                     }
                 }
             }
@@ -33,6 +34,7 @@ const getTeam: RequestHandler = async (req, res) => {
                     success: true,
                     data: allTeams,
                 });
+                return;
             }
             const pageTeams: Array<string> = [];
             for (let i = 0; i < limit && allTeams[i + limit * page]; i++)
@@ -41,12 +43,14 @@ const getTeam: RequestHandler = async (req, res) => {
                 success: true,
                 data: pageTeams,
             });
+            return;
         } else {
             const team = await Team.findOne({ ID: teamID });
             res.status(200).json({
                 sucess: true,
                 data: team,
             });
+            return;
         }
     } catch (e) {
         res.status(400).json({
@@ -56,6 +60,7 @@ const getTeam: RequestHandler = async (req, res) => {
                 message: e.message,
             },
         });
+        return;
     }
 };
 

--- a/srcs/swagger/controller/getTeam.tsx
+++ b/srcs/swagger/controller/getTeam.tsx
@@ -20,6 +20,18 @@
  *          type: integer
  *          default: 0
  *          minimum: 0
+ *      - in: query
+ *        name: progress
+ *        description: 값을 true로 줄 경우, 팀원 부족에 상관 없이 현재 진행중인 팀들만 반환합니다. state가 end가 아닌 팀들만 반환됩니다.
+ *        required: false
+ *        schema:
+ *          type: string
+ *      - in: query
+ *        name: subject
+ *        description: 특정 subject를 값으로 줄 경우, 그와 일치하는 subject를 가진 팀만 반환됩니다.
+ *        required: false
+ *        schema:
+ *          type: string
  *      responses:
  *          200:
  *              description: 팀 데이터 배열을 반환합니다. 팀 데이터 배열 범위 밖에 데이터를 요청했다면 빈 배열을 반환합니다. 범위는 [page * limit, page * limit + limit]입니다.


### PR DESCRIPTION
-progress 쿼리 값이 'true'일 때 state가 end인 팀 제거 필터링 된 후 반환됨
-subject 쿼리 값이 있을 때 그 값과 동이란 프로젝트가 아닌 팀은 필터링된 후 반환됨
-반환 되는 배열의 이름은 변하지 않음

resolved: #103 