### PR TITLE
feature : slack msg 발송 api 구현

### DIFF
--- a/srcs/controllers/controller.sendSlackMessage.tsx
+++ b/srcs/controllers/controller.sendSlackMessage.tsx
@@ -10,6 +10,7 @@ const channelID = process.env.SLACK_CHANNEL_ID;
 const sendSlackMessage: RequestHandler = async (req, res) => {
     try {
         const team = await Team.findOne({ ID: req.body.teamID });
+        if (team === null || team === undefined) throw new Error('This teamID does not exist.');
 
         let msg =
             team.subject +
@@ -32,9 +33,10 @@ const sendSlackMessage: RequestHandler = async (req, res) => {
             data: {
                 text: msg,
                 channel: channelID,
-                link_names: false,
+                link_names: true,
             },
         });
+        if (!sendMsg.data.ok) throw new Error(sendMsg.data.error);
 
         res.json({
             success: true,

--- a/srcs/controllers/controller.sendSlackMessage.tsx
+++ b/srcs/controllers/controller.sendSlackMessage.tsx
@@ -1,0 +1,55 @@
+import { RequestHandler } from 'express';
+import axios from 'axios';
+import dotenv from 'dotenv';
+import { Team } from '../models';
+
+dotenv.config();
+const BOT_TOKENS = process.env.SLACK_BOT_TOKENS;
+const channelID = process.env.SLACK_CHANNEL_ID;
+
+const sendSlackMessage: RequestHandler = async (req, res) => {
+    try {
+        const team = await Team.findOne({ ID: req.body.teamID });
+
+        let msg =
+            team.subject +
+            ' subject에 대한 팀매칭이 완료되었습니다!\n' +
+            '팀장: @' +
+            team.leaderID +
+            '\n팀원 : ';
+        for (let i = 0; i < team.memberID.length; i++) {
+            msg += '@' + team.memberID[i] + ' ';
+        }
+        msg += '\nnotion link: ' + team.notionLink + '\ngithub link:  ' + team.gitLink + '\n';
+
+        const sendMsg = await axios({
+            method: 'post',
+            url: 'https://slack.com/api/chat.postMessage',
+            headers: {
+                'Content-type': 'application/json',
+                Authorization: `Bearer ${BOT_TOKENS}`,
+            },
+            data: {
+                text: msg,
+                channel: channelID,
+                link_names: false,
+            },
+        });
+
+        res.json({
+            success: true,
+            team: team,
+            msg: msg,
+        });
+    } catch (e) {
+        res.status(400).json({
+            success: false,
+            error: {
+                code: e.name,
+                message: e.message,
+            },
+        });
+    }
+};
+
+export default sendSlackMessage;

--- a/srcs/controllers/index.tsx
+++ b/srcs/controllers/index.tsx
@@ -6,3 +6,4 @@ export { default as getTeam } from './controller.getTeam';
 export { default as removeUser2WaitList } from './controller.removeUser2WaitList';
 export { default as createGitRepo } from './controller.creatGitRepo';
 export { default as getWaitlist } from './controller.getWaitlist';
+export { default as sendSlackMessage } from './controller.sendSlackMessage';

--- a/srcs/routes/index.tsx
+++ b/srcs/routes/index.tsx
@@ -23,6 +23,7 @@ router.get('/user', controller.getUser);
 router.get('/user/:userID', controller.getUser);
 router.get('/waitlist', controller.getWaitlist);
 router.post('/waitlist', controller.addUser2WaitList);
+router.post('/sendSlackMessage', controller.sendSlackMessage);
 router.delete('/waitlist/:userID', controller.removeUser2WaitList);
 router.post('/addmember', controller.addUser2Team);
 router.get('/team', controller.getTeam);


### PR DESCRIPTION
- slack api를 사용하여 특정 채널에 msg보내는 기능 구현
- 성공적으로 msg발송시에 올바른  response반환 구현

resolved: #52 


문제사항
- 처음 설계는 비공개채널을 생성, 멤버 초대, msg발송하려 했으나 42born2code에서 채널 생성,채널에 초대와 관련된 권한을 안줍니다. -> 채널 하나를 따로 파고 해당채널에 @intraID 로 태그를해서 알림을 주는 방법으로 변경
- slack bot app용 token과 슬랙 channelID에 대해 env를 사용해 환경변수를 사용했습니다.