### PR TITLE
 팀 자동 매칭 시스템 작성

### DIFF
--- a/srcs/lib/index.tsx
+++ b/srcs/lib/index.tsx
@@ -1,1 +1,2 @@
 export { default as Scheduler } from './lib.Scheduler';
+export { default as Matcher } from './lib.Matcher';

--- a/srcs/lib/lib.Matcher.tsx
+++ b/srcs/lib/lib.Matcher.tsx
@@ -1,0 +1,151 @@
+import { Team } from '../models';
+import { Waitlist } from '../models';
+import { User } from '../models';
+
+const Matcher = async (): Promise<void> => {
+    const allWaitlist = await Waitlist.find({});
+    const matchSubject: Array<string> = [];
+    for (let i = 0; i < allWaitlist.length; i++) {
+        let flag = 0;
+        for (let j = 0; j < matchSubject.length; j++) {
+            if (matchSubject[j] === allWaitlist[i].subjectName) {
+                flag = 1;
+            }
+        }
+        if (flag === 0) {
+            matchSubject.push(allWaitlist[i].subjectName);
+        }
+    }
+    for (let i = 0; i < matchSubject.length; i++) {
+        const matchUser = allWaitlist.find({ subject: matchSubject[i] });
+        for (let i = 0; i < matchUser.length; i++) {
+            const user = await User.findOne({ ID: matchUser.user.userID });
+            matchUser[i].cluster = user.cluster;
+            if (user.cluster === null) {
+                matchUser[i].cluster = '개포';
+            }
+        }
+        while (matchUser.length) {
+            if (
+                matchUser.length === 3 ||
+                (matchUser.filter({ cluster: '개포' }).length === 2 &&
+                    matchUser.filter({ cluster: '서초 ' }) === 2)
+            ) {
+                await new Team({
+                    ID: matchSubject[i] + '_' + matchUser[0].user.userID,
+                    leaderID: matchUser[0].user.userID,
+                    memberID: [matchUser[1].user.userID, matchUser[2].user.userID],
+                    subject: matchSubject[i],
+                    state: 'progress',
+                    startDate: Date.now(),
+                    notionLink: '',
+                    gitLink: '',
+                    teamName: matchSubject[i] + '_' + matchUser[0].user.userID,
+                }).save;
+                for (let j = 0; j < 3; j++) {
+                    await User.findOneAndUpdate(
+                        { ID: matchUser[j].user.userID },
+                        {
+                            waitMatching: null,
+                            teamID: matchSubject[i] + '_' + matchUser[0].user.userID,
+                        },
+                        { new: true }
+                    );
+                    await Waitlist.findOneAndRemove({ user: matchUser[j].user });
+                    matchUser.splice(0, 1);
+                }
+            } else if (matchUser.length < 3) {
+                await new Team({
+                    ID: matchSubject[i] + '_' + matchUser[0].user.userID,
+                    leaderID: matchUser[0].user.userID,
+                    memberID: [matchUser[1].user.userID, matchUser[2].user.userID],
+                    subject: matchSubject[i],
+                    state: 'wait_member',
+                    startDate: Date.now(),
+                    notionLink: '',
+                    gitLink: '',
+                    teamName: matchSubject[i] + '_' + matchUser[0].user.userID,
+                }).save;
+                for (let j = 0; j < matchUser.length; j++) {
+                    await User.findOneAndUpdate(
+                        { ID: matchUser[j].user.userID },
+                        {
+                            waitMatching: null,
+                            teamID: matchSubject[i] + '_' + matchUser[0].user.userID,
+                        },
+                        { new: true }
+                    );
+                    await Waitlist.findOneAndRemove({ user: matchUser[j].user });
+                    matchUser.splice(0, 1);
+                }
+            } else if (matchUser.length > 3) {
+                const cluster1 = matchUser.filter({ cluster: '개포' });
+                const cluster2 = matchUser.filter({ cluster: '서초' });
+                if (cluster1.length >= 3) {
+                    await new Team({
+                        ID: matchSubject[i] + '_' + cluster1[0].user.userID,
+                        leaderID: cluster1[0].user.userID,
+                        memberID: [cluster1[1].user.userID, cluster1[2].user.userID],
+                        subject: matchSubject[i],
+                        state: 'progress',
+                        startDate: Date.now(),
+                        notionLink: '',
+                        gitLink: '',
+                        teamName: matchSubject[i] + '_' + cluster1[0].user.userID,
+                    }).save;
+                    for (let j = 0; j < 3; j++) {
+                        await User.findOneAndUpdate(
+                            { ID: cluster1[j].user.userID },
+                            {
+                                waitMatching: null,
+                                teamID: matchSubject[i] + '_' + cluster1[0].user.userID,
+                            },
+                            { new: true }
+                        );
+                        await Waitlist.findOneAndRemove({ user: cluster1[j].user });
+                        let flag = 0;
+                        for (let i = 0; flag === 0; i++) {
+                            if (matchUser[i].cluster === '개포') {
+                                matchUser.splice(i, 1);
+                                flag = 1;
+                            }
+                        }
+                    }
+                } else if (cluster2.length >= 3) {
+                    await new Team({
+                        ID: matchSubject[i] + '_' + cluster2[0].user.userID,
+                        leaderID: cluster2[0].user.userID,
+                        memberID: [cluster2[1].user.userID, cluster2[2].user.userID],
+                        subject: matchSubject[i],
+                        state: 'progress',
+                        startDate: Date.now(),
+                        notionLink: '',
+                        gitLink: '',
+                        teamName: matchSubject[i] + '_' + cluster2[0].user.userID,
+                    }).save;
+                    for (let j = 0; j < 3; j++) {
+                        await User.findOneAndUpdate(
+                            { ID: cluster2[j].user.userID },
+                            {
+                                waitMatching: null,
+                                teamID: matchSubject[i] + '_' + cluster2[0].user.userID,
+                            },
+                            { new: true }
+                        );
+                        await Waitlist.findOneAndRemove({ user: cluster2[j].user });
+                        let flag = 0;
+                        for (let i = 0; flag === 0; i++) {
+                            if (matchUser[i].cluster === '서초') {
+                                matchUser.splice(i, 1);
+                                flag = 1;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    return;
+};
+
+export default Matcher;


### PR DESCRIPTION
-express requestHandler를 쓰지 않아서 프론트엔드에서 사용할 수 없습니다.
-일단 매칭 알고리즘은 만들어졌습니다.
-waitlist에 데이터를 불러와서 매칭해야할 프로젝트들의 목록을 만듭니다.
-프로젝트 별로 인원을 나누고, 각 인원의 선호 클러스터를 불러와서 집어넣습니다
-특정 프로젝트에 매칭 신청한 인원이 3명 이하면 바로 팀을 만듭니다.
-팀이 만들어진 후 user.waitMatching과 teamID를 업데이트합니다. waitlist에서 해당 유저를 제거합니다.
-개포 2명 서초 2명일 경우 앞의 세명만 팀을 만듭니다.
-3명이상일 경우 각 클러스터에 3명이상 지원한 경우를 팀을 만듭니다.
-team 데이터 ID와 teamID는 명명법이 같습니다. 진행할 서브젝트 명_leaderID입니다. ID는 인트라 가입할때 유일한 값을 가지고, 유저가 같은 서브젝트에 중복지원하지 않는다는 가정아래서 유일한 값입니다.

resolved: #50 