### PR TITLE
getTeam API limit, page 쿼리 값 설정 개선

### DIFF
--- a/srcs/controllers/controller.getTeam.tsx
+++ b/srcs/controllers/controller.getTeam.tsx
@@ -5,15 +5,14 @@ const getTeam: RequestHandler = async (req, res) => {
     try {
         const teamID = req.params.teamID;
         if (!teamID) {
-            let limit = 5;
-            let page = 0;
-
-            if (req.query.limit) {
-                limit = parseInt(req.query.limit as string);
-            }
-            if (req.query.page) {
-                page = parseInt(req.query.page as string);
-            }
+            const limit =
+                req.query.limit === undefined || req.query.limit === null
+                    ? 5
+                    : parseInt(req.query.limit as string);
+            const page =
+                req.query.page === undefined || req.query.page === null
+                    ? 0
+                    : parseInt(req.query.page as string);
             const allTeams = await Team.find({});
             if ((req.query.progress as string) === 'true') {
                 for (let i = allTeams.length - 1; i >= 0; i--) {


### PR DESCRIPTION
-삼항 연산자를 사용해서 limit 값과 page값이 추가로 변경될 일이 줄었다. let에서 const로 변경했다.
-쿼리에 값이 들어오면 그 값을 숫자로 변경해서 할당했었는데, undefined거나 null이면 기본 값이 할당되게 바꿨다.
-쿼리값이 숫자가 아닌 문자들이 들어오면 0으로 할당 된다.

resolved:120