### PR TITLE
 getTeam API 페이지네이션 부분 개선 및 !조건문 구체화

### DIFF
--- a/srcs/controllers/controller.getTeam.tsx
+++ b/srcs/controllers/controller.getTeam.tsx
@@ -4,7 +4,7 @@ import { Team } from '../models';
 const getTeam: RequestHandler = async (req, res) => {
     try {
         const teamID = req.params.teamID;
-        if (!teamID) {
+        if (teamID === undefined || teamID === null) {
             let limit = 5;
             let page = 0;
 
@@ -14,7 +14,7 @@ const getTeam: RequestHandler = async (req, res) => {
             if (req.query.page) {
                 page = parseInt(req.query.page as string);
             }
-            const allTeams = await Team.find({});
+            let allTeams = await Team.find({});
             if ((req.query.progress as string) === 'true') {
                 for (let i = allTeams.length - 1; i >= 0; i--) {
                     if (allTeams[i].state === 'end') {
@@ -29,28 +29,24 @@ const getTeam: RequestHandler = async (req, res) => {
                     }
                 }
             }
-            if (!req.query.page && !req.query.limit) {
-                res.status(200).json({
-                    success: true,
-                    data: allTeams,
-                });
-                return;
+            if (
+                req.query.page !== undefined ||
+                req.query.limit !== undefined ||
+                req.query.page !== null ||
+                req.query.limit !== null
+            ) {
+                allTeams = allTeams.slice(limit * page, limit * page + limit);
             }
-            const pageTeams: Array<string> = [];
-            for (let i = 0; i < limit && allTeams[i + limit * page]; i++)
-                pageTeams.push(allTeams[i + limit * page]);
             res.status(200).json({
                 success: true,
-                data: pageTeams,
+                data: allTeams,
             });
-            return;
         } else {
             const team = await Team.findOne({ ID: teamID });
             res.status(200).json({
                 sucess: true,
                 data: team,
             });
-            return;
         }
     } catch (e) {
         res.status(400).json({
@@ -60,7 +56,6 @@ const getTeam: RequestHandler = async (req, res) => {
                 message: e.message,
             },
         });
-        return;
     }
 };
 


### PR DESCRIPTION
resolved:#127

조건식에 !들어간 부분 === undefined || === null 로 변경

for push로 특정 범위의 배열을 만들었는데 slice메소드 사용

page랑 limit 쿼리에 값을 넣어서 보냈는지 체크하고 아무 것도 안넣어서 보냈다면 allTeams를 반환하고 그 이후에 
페이지네이션을 한 후 반환했다.
이렇게 하면 반환을 두 번 하게 돼서 retrun 을 써줘야한다.
반환을 한 번 하도록 하는게 나을 것 같아서 page랑 limit중 값이 있는게 있다면 특정 범위의 배열을 새로 allTeams에 할당했다.
새로운 배열을 만들 필요가 없을 것 같아서 pageTeams는 제거하고 allTeams에 재할당했다.