### PR TITLE
refacor: 특정  Waitlist document 조회 로직 공통 모듈로 빼기

### DIFF
--- a/@types/types.d.tsx
+++ b/@types/types.d.tsx
@@ -26,6 +26,7 @@ export declare type tTeam = {
 
 export declare type tWaitlist = {
     _id: string
+    subjectName: string
     user: {
         userID: string
         waitedAt: Date

--- a/srcs/controllers/controller.addUser2Waitlist.tsx
+++ b/srcs/controllers/controller.addUser2Waitlist.tsx
@@ -12,7 +12,7 @@ const addUser2Waitlist: RequestHandler = async (req, res) => {
             throw new Error('This userID does not exist.');
 
         const WaitlistDocument = await findAllWaitlist(req.body.subjectName);
-        if (WaitlistDocument === undefined) throw new Error('Invalid subjectName');
+        if (WaitlistDocument instanceof Error) throw WaitlistDocument;
 
         for (let i = 0; i < WaitlistDocument.user.length; i++) {
             if (WaitlistDocument.user[i].userID === req.body.userID)

--- a/srcs/controllers/controller.addUser2Waitlist.tsx
+++ b/srcs/controllers/controller.addUser2Waitlist.tsx
@@ -12,7 +12,6 @@ const addUser2Waitlist: RequestHandler = async (req, res) => {
             throw new Error('This userID does not exist.');
 
         const WaitlistDocument = await findAllWaitlist(req.body.subjectName);
-        if (WaitlistDocument instanceof Error) throw WaitlistDocument;
 
         for (let i = 0; i < WaitlistDocument.user.length; i++) {
             if (WaitlistDocument.user[i].userID === req.body.userID)

--- a/srcs/controllers/controller.addUser2Waitlist.tsx
+++ b/srcs/controllers/controller.addUser2Waitlist.tsx
@@ -1,6 +1,7 @@
 import { RequestHandler } from 'express';
 import axios from 'axios';
 import { User, Waitlist } from '../models';
+import { findAllWaitlist } from '../lib';
 
 const addUser2Waitlist: RequestHandler = async (req, res) => {
     try {
@@ -10,11 +11,9 @@ const addUser2Waitlist: RequestHandler = async (req, res) => {
         if (UserDocument === null || UserDocument === undefined)
             throw new Error('This userID does not exist.');
 
-        const WaitlistDocument = await Waitlist.findOne({
-            subjectName: req.body.subjectName,
-        }).exec();
-        if (WaitlistDocument === null || WaitlistDocument === undefined)
-            throw new Error('Invalid subjectName');
+        const WaitlistDocument = await findAllWaitlist(req.body.subjectName);
+        if (WaitlistDocument === undefined) throw new Error('Invalid subjectName');
+
         for (let i = 0; i < WaitlistDocument.user.length; i++) {
             if (WaitlistDocument.user[i].userID === req.body.userID)
                 throw new Error(

--- a/srcs/controllers/controller.removeUser2WaitList.tsx
+++ b/srcs/controllers/controller.removeUser2WaitList.tsx
@@ -11,7 +11,7 @@ const removeUser2Waitlist: RequestHandler = async (req, res) => {
             throw new Error('This userID not registered in any subject');
 
         const WaitlistDocument = await findAllWaitlist(UserDocument.waitMatching);
-        if (WaitlistDocument === undefined) throw new Error('Invalid subjectname');
+        if (WaitlistDocument instanceof Error) throw WaitlistDocument;
 
         let WaitlistUserInfo = {};
         for (let i = 0; i < WaitlistDocument.user.length; i++) {

--- a/srcs/controllers/controller.removeUser2WaitList.tsx
+++ b/srcs/controllers/controller.removeUser2WaitList.tsx
@@ -11,7 +11,6 @@ const removeUser2Waitlist: RequestHandler = async (req, res) => {
             throw new Error('This userID not registered in any subject');
 
         const WaitlistDocument = await findAllWaitlist(UserDocument.waitMatching);
-        if (WaitlistDocument instanceof Error) throw WaitlistDocument;
 
         let WaitlistUserInfo = {};
         for (let i = 0; i < WaitlistDocument.user.length; i++) {

--- a/srcs/controllers/controller.removeUser2WaitList.tsx
+++ b/srcs/controllers/controller.removeUser2WaitList.tsx
@@ -1,5 +1,6 @@
 import { RequestHandler } from 'express';
 import { User, Waitlist } from '../models';
+import { findAllWaitlist } from '../lib';
 
 const removeUser2Waitlist: RequestHandler = async (req, res) => {
     try {
@@ -9,12 +10,10 @@ const removeUser2Waitlist: RequestHandler = async (req, res) => {
         if (UserDocument.waitMatching === null)
             throw new Error('This userID not registered in any subject');
 
-        const WaitlistDocument = await Waitlist.findOne({
-            subjectName: UserDocument.waitMatching,
-        }).exec();
-        if (WaitlistDocument === null || WaitlistDocument === undefined)
-            throw new Error('This subjectName does not exist.');
-        let WaitlistUserInfo = null;
+        const WaitlistDocument = await findAllWaitlist(UserDocument.waitMatching);
+        if (WaitlistDocument === undefined) throw new Error('Invalid subjectname');
+
+        let WaitlistUserInfo = {};
         for (let i = 0; i < WaitlistDocument.user.length; i++) {
             if (WaitlistDocument.user[i].userID === req.params.userID) {
                 WaitlistUserInfo = WaitlistDocument.user[i];

--- a/srcs/lib/index.tsx
+++ b/srcs/lib/index.tsx
@@ -1,2 +1,3 @@
 export { default as Scheduler } from './lib.Scheduler';
 export { default as Matcher } from './lib.Matcher';
+export { default as findAllWaitlist } from './lib.allWaitlist';

--- a/srcs/lib/lib.allWaitlist.tsx
+++ b/srcs/lib/lib.allWaitlist.tsx
@@ -8,7 +8,7 @@ const findAllWaitlist: (subjectName: string) => Promise<tWaitlist | Error> = asy
         const WaitlistDocument = await Waitlist.findOne({
             subjectName: subjectName,
         });
-        if (WaitlistDocument == null || WaitlistDocument == undefined)
+        if (WaitlistDocument === null || WaitlistDocument === undefined)
             throw new Error('Invalid subjectName');
         return WaitlistDocument;
     } catch (error) {

--- a/srcs/lib/lib.allWaitlist.tsx
+++ b/srcs/lib/lib.allWaitlist.tsx
@@ -1,15 +1,18 @@
 import { Waitlist } from '../models';
 import { tWaitlist } from '../../@types/types.d';
 
-const findAllWaitlist: (subjectName: string) => Promise<tWaitlist> = async (subjectName) => {
+const findAllWaitlist: (subjectName: string) => Promise<tWaitlist | Error> = async (
+    subjectName
+) => {
     try {
         const WaitlistDocument = await Waitlist.findOne({
             subjectName: subjectName,
         });
-        if (WaitlistDocument == null || WaitlistDocument == undefined) return undefined;
+        if (WaitlistDocument == null || WaitlistDocument == undefined)
+            throw new Error('Invalid subjectName');
         return WaitlistDocument;
-    } catch (err) {
-        return undefined;
+    } catch (error) {
+        return error;
     }
 };
 

--- a/srcs/lib/lib.allWaitlist.tsx
+++ b/srcs/lib/lib.allWaitlist.tsx
@@ -1,0 +1,16 @@
+import { Waitlist } from '../models';
+import { tWaitlist } from '../../@types/types.d';
+
+const findAllWaitlist: (subjectName: string) => Promise<tWaitlist> = async (subjectName) => {
+    try {
+        const WaitlistDocument = await Waitlist.findOne({
+            subjectName: subjectName,
+        });
+        if (WaitlistDocument == null || WaitlistDocument == undefined) return undefined;
+        return WaitlistDocument;
+    } catch (err) {
+        return undefined;
+    }
+};
+
+export default findAllWaitlist;

--- a/srcs/lib/lib.allWaitlist.tsx
+++ b/srcs/lib/lib.allWaitlist.tsx
@@ -1,19 +1,13 @@
 import { Waitlist } from '../models';
 import { tWaitlist } from '../../@types/types.d';
 
-const findAllWaitlist: (subjectName: string) => Promise<tWaitlist | Error> = async (
-    subjectName
-) => {
-    try {
-        const WaitlistDocument = await Waitlist.findOne({
-            subjectName: subjectName,
-        });
-        if (WaitlistDocument === null || WaitlistDocument === undefined)
-            throw new Error('Invalid subjectName');
-        return WaitlistDocument;
-    } catch (error) {
-        return error;
-    }
+const findAllWaitlist: (subjectName: string) => Promise<tWaitlist> = async (subjectName) => {
+    const WaitlistDocument = await Waitlist.findOne({
+        subjectName: subjectName,
+    });
+    if (WaitlistDocument === null || WaitlistDocument === undefined)
+        throw new Error('Invalid subjectName');
+    return WaitlistDocument;
 };
 
 export default findAllWaitlist;


### PR DESCRIPTION
    refacor: 특정 subject문서 조회 로직 공통 모듈로 빼기
    
    - 특정 Waitlist document 조회 로직 공통모듈로 빼기
    - lib.allWaitlist.tsx로 뺏습니다.
    - lib/index.tsx에 작성한 공통모듈 export하기
    - tWaitlist 타입에 subjectName가 빠져있어 수정
    - post /waitlist api로직 공통모듈 사용하도록 수정
    - delete /waitlist api로직 공통모듈 사용하도록 수정
    - 회의에서 논의한데로 공통 모듈 에러처리 방식 통일

resolved: #126 