### PR TITLE
refactor: delete /waitlist api 리팩토링

### DIFF
--- a/srcs/controllers/controller.removeUser2WaitList.tsx
+++ b/srcs/controllers/controller.removeUser2WaitList.tsx
@@ -1,12 +1,10 @@
 import { RequestHandler } from 'express';
 import { User, Waitlist } from '../models';
-import { findOneWaitlist } from '../lib';
+import { findOneWaitlist, findOneUser } from '../lib';
 
 const removeUser2Waitlist: RequestHandler = async (req, res) => {
     try {
-        const UserDocument = await User.findOne({ ID: req.params.userID }).exec();
-        if (UserDocument === null || UserDocument === undefined)
-            throw new Error('This userID does not exist.');
+        const UserDocument = await findOneUser(req.body.userID);
         if (UserDocument.waitMatching === null)
             throw new Error('This userID not registered in any subject');
 

--- a/srcs/controllers/controller.removeUser2WaitList.tsx
+++ b/srcs/controllers/controller.removeUser2WaitList.tsx
@@ -30,13 +30,13 @@ const removeUser2Waitlist: RequestHandler = async (req, res) => {
                 deadline: null,
             },
             { new: true, runValidators: true }
-        ).exec();
+        );
 
         const ChangedWaitlist = await Waitlist.findOneAndUpdate(
             { subjectName: WaitlistDocument.subjectName },
             { $pull: { user: WaitlistUserInfo } },
             { new: true, runValidators: true }
-        ).exec();
+        );
 
         res.status(200).json({
             success: true,

--- a/srcs/controllers/controller.removeUser2WaitList.tsx
+++ b/srcs/controllers/controller.removeUser2WaitList.tsx
@@ -19,7 +19,7 @@ const removeUser2Waitlist: RequestHandler = async (req, res) => {
         }
         if (WaitlistUserInfo === null) {
             throw new Error(
-                'This userID not registered in ' + WaitlistDocument.subjectName + 'subject'
+                `This userID not registered in ${WaitlistDocument.subjectName} subject`
             );
         }
 


### PR DESCRIPTION
-  findOneUser[공통모듈] 적용하기
- 문자열 리터럴 적용하기
- 몽구스 메소드 형식 통일하기
- 에러처리 함수화하기
-  map,indexof메소드사용하여 유저가 매칭 대기열에 있는지 확인하는 로직 가독성 향상

resolved: #146 