### PR TITLE
hotfix: 슬랙 msg발송 모듈 에러처리 수정

### DIFF
--- a/srcs/lib/lib.sendSlackMessage.tsx
+++ b/srcs/lib/lib.sendSlackMessage.tsx
@@ -13,7 +13,7 @@ const sendMsgPromise: (msg: string) => Promise<tSlackdata> = async (msg) => {
         url: 'https://slack.com/api/chat.postMessage',
         headers: {
             'Content-type': 'application/json',
-            Authorization: `Bearer ${BOT_TOKENS}`,
+            Authorization: `Bearer ${channelID}`,
         },
         data: {
             text: msg,
@@ -24,17 +24,21 @@ const sendMsgPromise: (msg: string) => Promise<tSlackdata> = async (msg) => {
 };
 
 const sendSlackMessage: (teamID: string) => Promise<void> = async (teamID) => {
-    const team = await findOneTeam(teamID);
+    try {
+        const team = await findOneTeam(teamID);
 
-    const msg = `${team.subject} subject에 대한 팀매칭이 완료 되었습니다.
-    팀장 : @${team.leaderID}
-    팀원 : @${team.memberID.join(' @')}
-    notion link : ${team.notionLink}
-    github link : ${team.gitLink}`;
+        const msg = `${team.subject} subject에 대한 팀매칭이 완료 되었습니다.
+        팀장 : @${team.leaderID}
+        팀원 : @${team.memberID.join(' @')}
+        notion link : ${team.notionLink}
+        github link : ${team.gitLink}`;
 
-    await sendMsgPromise(msg).then((slackResponse) => {
-        if (slackResponse.ok === false) throw new Error(`slack API ${slackResponse.error}`);
-    });
+        await sendMsgPromise(msg).then((slackResponse) => {
+            if (slackResponse.ok === false) throw new Error(`slack API ${slackResponse.error}`);
+        });
+    } catch (e) {
+        console.error(e);
+    }
 };
 
 export default sendSlackMessage;

--- a/srcs/lib/lib.sendSlackMessage.tsx
+++ b/srcs/lib/lib.sendSlackMessage.tsx
@@ -13,7 +13,7 @@ const sendMsgPromise: (msg: string) => Promise<tSlackdata> = async (msg) => {
         url: 'https://slack.com/api/chat.postMessage',
         headers: {
             'Content-type': 'application/json',
-            Authorization: `Bearer ${channelID}`,
+            Authorization: `Bearer ${BOT_TOKENS}`,
         },
         data: {
             text: msg,


### PR DESCRIPTION
- 호출자로 에러를 throw해서 app crashed로 프로그램 자체가 중단되지 않고 error만 출력하도록 수정

resolved: #174 