### PR TITLE
fix: 생성되는 깃허브 저장소 이름에 중복되는 부분 제거

### DIFF
--- a/srcs/lib/lib.createGitRepo.tsx
+++ b/srcs/lib/lib.createGitRepo.tsx
@@ -17,7 +17,7 @@ const createGitRepo: (subject: string, ID: string) => Promise<string | null> = a
                 Authorization: `token ${process.env.GIT_TOKEN}`,
             },
             data: {
-                name: `Matching42_${subject}_${ID}`,
+                name: `Matching42_${ID}`,
                 auto_init: true,
                 private: true,
             },


### PR DESCRIPTION
- 깃허브 저장소 이름 수정

resolved: #199 
