### PR TITLE
fix: 깃 저장소가 public으로 생성되도록 변경

### DIFF
--- a/srcs/lib/lib.createGitRepo.tsx
+++ b/srcs/lib/lib.createGitRepo.tsx
@@ -19,7 +19,7 @@ const createGitRepo: (subject: string, ID: string) => Promise<string | null> = a
             data: {
                 name: `Matching42_${subject}_${ID}`,
                 auto_init: true,
-                private: true,
+                private: false,
             },
         });
         return createResult.data.html_url;


### PR DESCRIPTION
- 깃 저장소가 public으로 생성되도록 변경

resolved: #202 